### PR TITLE
Add new input parameter to control source fetching

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,11 @@ inputs:
     required: true
     default: '*.spec'                     #Any spec file in top 
 
+  use_sources_from_repo:
+    description: 'whether to use the sources in the current github repository to build the RPM from'
+    required: false
+    default: true
+
 outputs:
   source_rpm_path:
     description: 'path to Source RPM file'

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,17 +23,17 @@ async function run() {
 
     // Read spec file and get values 
     var data = fs.readFileSync(specFile, 'utf8');
-    let name = '';       
+    let name = '';
     let version = '';
 
-    for (var line of data.split('\n')){
-        var lineArray = line.split(/[ ]+/);
-        if(lineArray[0].includes('Name')){
-            name = name+lineArray[1];
-        }
-        if(lineArray[0].includes('Version')){
-            version = version+lineArray[1];
-        }   
+    for (var line of data.split('\n')) {
+      var lineArray = line.split(/[ ]+/);
+      if (lineArray[0].includes('Name')) {
+        name = name + lineArray[1];
+      }
+      if (lineArray[0].includes('Version')) {
+        version = version + lineArray[1];
+      }
     }
     console.log(`name: ${name}`);
     console.log(`version: ${version}`);
@@ -56,9 +56,6 @@ async function run() {
 
       // Create Source tar.gz file 
       await exec.exec(`tar -czvf ${name}-${version}.tar.gz ${name}-${version}`);
-
-      // // list files in current directory /github/workspace/
-      // await exec.exec('ls -la ');
 
       // Copy tar.gz file to source path
       await exec.exec(`cp ${name}-${version}.tar.gz /github/home/rpmbuild/SOURCES/`);
@@ -86,13 +83,12 @@ async function run() {
         //some err occurred
         console.error(err)
       } else {
-          // the *entire* stdout and stderr (buffered)
-          console.log(`stdout: ${stdout}`);
-          myOutput = myOutput+`${stdout}`.trim();
-          console.log(`stderr: ${stderr}`);
-        }
-      });
-
+        // the *entire* stdout and stderr (buffered)
+        console.log(`stdout: ${stdout}`);
+        myOutput = myOutput + `${stdout}`.trim();
+        console.log(`stderr: ${stderr}`);
+      }
+    });
 
     // only contents of workspace can be changed by actions and used by subsequent actions 
     // So copy all generated rpms into workspace , and publish output path relative to workspace (/github/workspace)
@@ -104,16 +100,13 @@ async function run() {
 
     await exec.exec(`ls -la rpmbuild/SRPMS`);
     await exec.exec(`ls -la rpmbuild/RPMS`);
-    
+
     // set outputs to path relative to workspace ex ./rpmbuild/
     core.setOutput("source_rpm_dir_path", `rpmbuild/SRPMS/`);              // path to  SRPMS directory
     core.setOutput("source_rpm_path", `rpmbuild/SRPMS/${myOutput}`);       // path to Source RPM file
     core.setOutput("source_rpm_name", `${myOutput}`);                      // name of Source RPM file
     core.setOutput("rpm_dir_path", `rpmbuild/RPMS/`);                      // path to RPMS directory
     core.setOutput("rpm_content_type", "application/octet-stream");        // Content-type for Upload
-    
-
-
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
The default is that this action is always trying to pull the sources from the repository in which this action is defined.
That is not very useful when there is already a source parameter defined in the RPM spec file.